### PR TITLE
Update __init__.py

### DIFF
--- a/custom_components/blinds_controller/__init__.py
+++ b/custom_components/blinds_controller/__init__.py
@@ -14,7 +14,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = entry.data
     # Load the cover platform with the configuration entry
     hass.async_create_task(
-        hass.config_entries.async_forward_entry_setups(entry, "cover")
+        hass.config_entries.async_forward_entry_setups(entry, ["cover"])
     )
     return True
 

--- a/custom_components/blinds_controller/__init__.py
+++ b/custom_components/blinds_controller/__init__.py
@@ -14,7 +14,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = entry.data
     # Load the cover platform with the configuration entry
     hass.async_create_task(
-        hass.config_entries.async_forward_entry_setup(entry, "cover")
+        hass.config_entries.async_forward_entry_setups(entry, "cover")
     )
     return True
 


### PR DESCRIPTION
Replaced deprecated call to hass.config_entries.async_forward_entry_setup with hass.config_entries.async_forward_entry_setup**s** to ensure compatibility with Home Assistant 2025.6, see https://developers.home-assistant.io/blog/2024/06/12/async_forward_entry_setups/

Have not tried this on a running system, so may need debugging.